### PR TITLE
Generate tissue integration table for the dashboard - part 2

### DIFF
--- a/data_processing/scripts/dashboard_utils.py
+++ b/data_processing/scripts/dashboard_utils.py
@@ -142,7 +142,9 @@ def get_tissue_integration_results_csv(working_dir: str, s3_access_file: str):
         CSV_HEADER_DONOR_COUNT,
         CSV_HEADER_DONORS,
         CSV_HEADER_CELL_COUNT,
-        CSV_HEADER_ANNDATA,
+        CSV_HEADER_SAMPLE_COUNT,
+        CSV_HEADER_SAMPLES,
+        CSV_HEADER_ANNDATA,    
     ]
     writer = csv.DictWriter(csv_file, fieldnames=field_names)
     writer.writeheader()


### PR DESCRIPTION
This change adds in the ability to download and parse the anndata associated with the tissue, if one exists. We pull various info such as cell count, donor count, list of donors, sample count, list of samples, etc.